### PR TITLE
Fix remote Chrome debugging settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,14 +186,20 @@ python webui.py --ip 0.0.0.0 --port 8080 --theme Dark
 CHROME_PATH="C:\Program Files\Google\Chrome\Application\chrome.exe"
 CHROME_USER_DATA="C:\Users\YourUsername\AppData\Local\Google\Chrome\User Data"
 CHROME_PERSISTENT_SESSION=true
+CHROME_DEBUGGING_HOST=localhost
+CHROME_DEBUGGING_PORT=9222
 ```
+Set `CHROME_DEBUGGING_HOST` to the address of your remote Chrome instance when connecting to a remote browser.
 
 **macOS Configuration:**
 ```env
 CHROME_PATH="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 CHROME_USER_DATA="~/Library/Application Support/Google/Chrome/Profile 1"
 CHROME_PERSISTENT_SESSION=true
+CHROME_DEBUGGING_HOST=localhost
+CHROME_DEBUGGING_PORT=9222
 ```
+Set `CHROME_DEBUGGING_HOST` to the address of your remote Chrome instance when connecting to a remote browser.
 
 ---
 

--- a/src/browser/custom_browser.py
+++ b/src/browser/custom_browser.py
@@ -13,54 +13,68 @@ from browser_use.browser.browser import Browser
 from browser_use.browser.context import BrowserContext, BrowserContextConfig
 from playwright.async_api import BrowserContext as PlaywrightBrowserContext
 import logging
+import os
 
 from .custom_context import CustomBrowserContext
 
 logger = logging.getLogger(__name__)
 
+
 class CustomBrowser(Browser):
 
     async def new_context(
-        self,
-        config: BrowserContextConfig = BrowserContextConfig()
+        self, config: BrowserContextConfig = BrowserContextConfig()
     ) -> CustomBrowserContext:
         return CustomBrowserContext(config=config, browser=self)
-    
-    async def _setup_browser_with_instance(self, playwright: Playwright) -> PlaywrightBrowser:
+
+    async def _setup_browser_with_instance(
+        self, playwright: Playwright
+    ) -> PlaywrightBrowser:
         """Sets up and returns a Playwright Browser instance with anti-detection measures."""
         if not self.config.chrome_instance_path:
-            raise ValueError('Chrome instance path is required')
+            raise ValueError("Chrome instance path is required")
         import subprocess
 
         import requests
 
+        chrome_host = os.getenv("CHROME_DEBUGGING_HOST", "localhost")
+        chrome_port = os.getenv("CHROME_DEBUGGING_PORT", "9222")
+        endpoint = f"http://{chrome_host}:{chrome_port}"
+
         try:
             # Check if browser is already running
-            response = requests.get('http://localhost:9222/json/version', timeout=2)
+            response = requests.get(f"{endpoint}/json/version", timeout=2)
             if response.status_code == 200:
-                logger.info('Reusing existing Chrome instance')
+                logger.info("Reusing existing Chrome instance")
                 browser = await playwright.chromium.connect_over_cdp(
-                    endpoint_url='http://localhost:9222',
+                    endpoint_url=endpoint,
                     timeout=20000,  # 20 second timeout for connection
                 )
                 return browser
         except requests.ConnectionError:
-            logger.debug('No existing Chrome instance found, starting a new one')
+            logger.debug("No existing Chrome instance found, starting a new one")
 
         # Start a new Chrome instance
-        subprocess.Popen(
-            [
-                self.config.chrome_instance_path,
-                '--remote-debugging-port=9222',
-            ] + self.config.extra_chromium_args,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-  
+        if chrome_host in ("localhost", "127.0.0.1"):
+            subprocess.Popen(
+                [
+                    self.config.chrome_instance_path,
+                    f"--remote-debugging-port={chrome_port}",
+                ]
+                + self.config.extra_chromium_args,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        else:
+            logger.error(
+                f"Cannot start Chrome automatically for remote host {chrome_host}"
+            )
+            raise RuntimeError(f"Chrome remote debugging not available at {endpoint}")
+
         # try to connect first in case the browser have not started
         for _ in range(10):
             try:
-                response = requests.get('http://localhost:9222/json/version', timeout=2)
+                response = requests.get(f"{endpoint}/json/version", timeout=2)
                 if response.status_code == 200:
                     break
             except requests.ConnectionError:
@@ -70,12 +84,12 @@ class CustomBrowser(Browser):
         # Attempt to connect again after starting a new instance
         try:
             browser = await playwright.chromium.connect_over_cdp(
-                endpoint_url='http://localhost:9222',
+                endpoint_url=endpoint,
                 timeout=20000,  # 20 second timeout for connection
             )
             return browser
         except Exception as e:
-            logger.error(f'Failed to start a new Chrome instance.: {str(e)}')
+            logger.error(f"Failed to start a new Chrome instance.: {str(e)}")
             raise RuntimeError(
-                ' To start chrome in Debug mode, you need to close all existing Chrome instances and try again otherwise we can not connect to the instance.'
+                " To start chrome in Debug mode, you need to close all existing Chrome instances and try again otherwise we can not connect to the instance."
             )

--- a/src/utils/default_config_settings.py
+++ b/src/utils/default_config_settings.py
@@ -17,13 +17,16 @@ def default_config():
         "llm_temperature": 1.0,
         "llm_base_url": "https://generativelanguage.googleapis.com/v1beta/models",
         "llm_api_key": "AIzaSyCxPRTsHIf-2NwAdyXqgjrOzYRgzXZFAcg",
-        "use_own_browser": os.getenv("CHROME_PERSISTENT_SESSION", "false").lower() == "true",
+        "use_own_browser": os.getenv("CHROME_PERSISTENT_SESSION", "false").lower()
+        == "true",
         "keep_browser_open": True,
         "headless": False,
         "disable_security": True,
         "enable_recording": True,
         "window_w": 1280,
         "window_h": 1100,
+        "chrome_debugging_host": os.getenv("CHROME_DEBUGGING_HOST", "localhost"),
+        "chrome_debugging_port": int(os.getenv("CHROME_DEBUGGING_PORT", "9222")),
         "save_recording_path": "./tmp/record_videos",
         "save_trace_path": "./tmp/traces",
         "save_agent_history_path": "./tmp/agent_history",
@@ -34,7 +37,7 @@ def default_config():
 def load_config_from_file(config_file):
     """Load settings from a UUID.pkl file."""
     try:
-        with open(config_file, 'rb') as f:
+        with open(config_file, "rb") as f:
             settings = pickle.load(f)
         return settings
     except Exception as e:
@@ -45,7 +48,7 @@ def save_config_to_file(settings, save_dir="./tmp/webui_settings"):
     """Save the current settings to a UUID.pkl file with a UUID name."""
     os.makedirs(save_dir, exist_ok=True)
     config_file = os.path.join(save_dir, f"{uuid.uuid4()}.pkl")
-    with open(config_file, 'wb') as f:
+    with open(config_file, "wb") as f:
         pickle.dump(settings, f)
     return f"Configuration saved to {config_file}"
 
@@ -88,10 +91,21 @@ def update_ui_from_config(config_file):
                 gr.update(value=loaded_config.get("use_vision", True)),
                 gr.update(value=loaded_config.get("tool_calling_method", True)),
                 gr.update(value=loaded_config.get("llm_provider", "gemini")),
-                gr.update(value=loaded_config.get("llm_model_name", "gemini-2.0-flash")),
+                gr.update(
+                    value=loaded_config.get("llm_model_name", "gemini-2.0-flash")
+                ),
                 gr.update(value=loaded_config.get("llm_temperature", 1.0)),
-                gr.update(value=loaded_config.get("llm_base_url", "https://generativelanguage.googleapis.com/v1beta/models")),
-                gr.update(value=loaded_config.get("llm_api_key", "AIzaSyCxPRTsHIf-2NwAdyXqgjrOzYRgzXZFAcg")),
+                gr.update(
+                    value=loaded_config.get(
+                        "llm_base_url",
+                        "https://generativelanguage.googleapis.com/v1beta/models",
+                    )
+                ),
+                gr.update(
+                    value=loaded_config.get(
+                        "llm_api_key", "AIzaSyCxPRTsHIf-2NwAdyXqgjrOzYRgzXZFAcg"
+                    )
+                ),
                 gr.update(value=loaded_config.get("use_own_browser", False)),
                 gr.update(value=loaded_config.get("keep_browser_open", False)),
                 gr.update(value=loaded_config.get("headless", False)),
@@ -99,24 +113,66 @@ def update_ui_from_config(config_file):
                 gr.update(value=loaded_config.get("enable_recording", True)),
                 gr.update(value=loaded_config.get("window_w", 1280)),
                 gr.update(value=loaded_config.get("window_h", 1100)),
-                gr.update(value=loaded_config.get("save_recording_path", "./tmp/record_videos")),
+                gr.update(
+                    value=loaded_config.get(
+                        "save_recording_path", "./tmp/record_videos"
+                    )
+                ),
                 gr.update(value=loaded_config.get("save_trace_path", "./tmp/traces")),
-                gr.update(value=loaded_config.get("save_agent_history_path", "./tmp/agent_history")),
+                gr.update(
+                    value=loaded_config.get(
+                        "save_agent_history_path", "./tmp/agent_history"
+                    )
+                ),
                 gr.update(value=loaded_config.get("task", "")),
-                "Configuration loaded successfully."
+                "Configuration loaded successfully.",
             )
         else:
             return (
-                gr.update(), gr.update(), gr.update(), gr.update(), gr.update(),
-                gr.update(), gr.update(), gr.update(), gr.update(), gr.update(),
-                gr.update(), gr.update(), gr.update(), gr.update(), gr.update(),
-                gr.update(), gr.update(), gr.update(), gr.update(), gr.update(),
-                gr.update(), "Error: Invalid configuration file."
+                gr.update(),
+                gr.update(),
+                gr.update(),
+                gr.update(),
+                gr.update(),
+                gr.update(),
+                gr.update(),
+                gr.update(),
+                gr.update(),
+                gr.update(),
+                gr.update(),
+                gr.update(),
+                gr.update(),
+                gr.update(),
+                gr.update(),
+                gr.update(),
+                gr.update(),
+                gr.update(),
+                gr.update(),
+                gr.update(),
+                gr.update(),
+                "Error: Invalid configuration file.",
             )
     return (
-        gr.update(), gr.update(), gr.update(), gr.update(), gr.update(),
-        gr.update(), gr.update(), gr.update(), gr.update(), gr.update(),
-        gr.update(), gr.update(), gr.update(), gr.update(), gr.update(),
-        gr.update(), gr.update(), gr.update(), gr.update(), gr.update(),
-        gr.update(), "No file selected."
+        gr.update(),
+        gr.update(),
+        gr.update(),
+        gr.update(),
+        gr.update(),
+        gr.update(),
+        gr.update(),
+        gr.update(),
+        gr.update(),
+        gr.update(),
+        gr.update(),
+        gr.update(),
+        gr.update(),
+        gr.update(),
+        gr.update(),
+        gr.update(),
+        gr.update(),
+        gr.update(),
+        gr.update(),
+        gr.update(),
+        gr.update(),
+        "No file selected.",
     )


### PR DESCRIPTION
## Summary
- add support for remote Chrome debugging host and port
- document debugging env vars in README

## Testing
- `black src/browser/custom_browser.py src/utils/default_config_settings.py`
- `pytest -k "nonexistent" -q` *(fails: 16 deselected)*

------
https://chatgpt.com/codex/tasks/task_e_6849ec5f3a848333ac3d0c7fce686e97